### PR TITLE
Allow update to convert jp2 to jpg and upload to S3

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from copy import copy
 from collections import OrderedDict
 from datetime import datetime, date, timedelta
 from sentinel_s3 import range_metadata, single_metadata
+from thumbs import thumbnail_writer
 
 from elasticsearch import Elasticsearch, RequestError
 
@@ -170,7 +171,7 @@ def geometry_check(meta):
 
 
 @click.command()
-@click.argument('ops', metavar='<operations: choices: s3 | es | disk>', nargs=-1)
+@click.argument('ops', metavar='<operations: choices: s3 | es | disk | thumbs>', nargs=-1)
 @click.option('--product', default=None, help='Product name. If given only the given product is processed.')
 @click.option('--start', default=None, help='Start Date. Format: YYYY-MM-DD')
 @click.option('--end', default=None, help='End Date. Format: YYYY-MM-DD')
@@ -187,7 +188,8 @@ def main(ops, product, start, end, concurrency, es_host, es_port, folder, verbos
     accepted_args = {
         'es': elasticsearch_updater,
         's3': s3_writer,
-        'disk': file_writer
+        'disk': file_writer,
+        'thumbs': thumbnail_writer
     }
 
     writers = []

--- a/thumbs.py
+++ b/thumbs.py
@@ -1,0 +1,53 @@
+import os
+import rasterio
+import boto3
+
+thumbs_bucket_name = os.getenv('THUMBS_BUCKETNAME', 'ad-thumbnails')
+s3 = boto3.resource('s3')
+
+
+def thumbnail_writer(product_dir, metadata):
+    """
+    Extra function to convert images to JPEG, then upload to S3 and call
+    the ES metadata writer afterwards.
+    """
+
+    from main import elasticsearch_updater
+    # Download original thumbnail
+    orig_url = metadata['thumbnail']
+
+    # Use GDAL to convert to jpg
+    with rasterio.drivers():
+        with rasterio.open(orig_url) as src:
+            r, g, b = src.read()
+
+            # Build up output file name
+            output_file = str(metadata['utm_zone']) + metadata['latitude_band'] + \
+                metadata['grid_square'] + str(metadata['date'].replace('-', '')) + \
+                metadata['path'][-1] + '.jpg'
+
+            # Copy and update profile
+            profile = src.profile
+            profile.update(driver='JPEG')
+
+            # Write to output jpeg
+            with rasterio.open(output_file, 'w', **profile) as dst:
+                dst.write_band(1, r)
+                dst.write_band(2, g)
+                dst.write_band(3, b)
+
+    # Upload thumbnail to S3
+    s3.Object(thumbs_bucket_name, output_file).put(Body=open(output_file),
+                                                   ACL='public-read',
+                                                   ContentType='image/jpeg')
+
+    # Delete thumbnail and associated files
+    if os.path.exists(output_file):
+        os.remove(output_file)
+    if os.path.exists(output_file + '.aux.xml'):
+        os.remove(output_file + '.aux.xml')
+
+    # Update metadata record
+    metadata['thumbnail'] = 'https://' + thumbs_bucket_name + \
+        '.s3.amazonaws.com/' + output_file
+    elasticsearch_updater(product_dir, metadata)


### PR DESCRIPTION
After conversion and uploading to S3, calls elasticsearch_writer with new thumbnail url.
